### PR TITLE
prevent catch_exception_raise from being affected by dead_strip

### DIFF
--- a/src/client/mac/handler/exception_handler.cc
+++ b/src/client/mac/handler/exception_handler.cc
@@ -133,7 +133,7 @@ extern "C" {
                                       exception_type_t exception,
                                       exception_data_t code,
                                       mach_msg_type_number_t code_count)
-      __attribute__((visibility("default")));
+      __attribute__((visibility("default"), used));
 }
 #endif
 


### PR DESCRIPTION
The linker's dead_strip option was removing the catch_exception_raise symbol.  Without this symbol, 
exc_server would cause PMS to exit. We did not notice before because this exit happens after the minidump is generated, however if a child process crashes then this will also cause PMS to exit (defeating the purpose of child processes).  The added `used` property preserves the symbol.

NOTE: this only affect macos (and potentially ios)